### PR TITLE
added get grounding line method

### DIFF
--- a/src/WAVI.jl
+++ b/src/WAVI.jl
@@ -373,12 +373,12 @@ end
 
 # Utility functions
 """
-     get_GLx(wavi)
+     get_glx(wavi)
 
 Return the grounding line in the form x = x(y). Assumes each y-row has at least
 one grid point where ice grounded and one where ice floating.
 """
-function get_GLx(wavi)
+function get_glx(wavi)
       glmask=diff(sign.(wavi.gh.haf),dims=1).==-2 #calculate where sign of height above floating passes thru zero
       glx1=wavi.gh.xx[1:end-1,:][glmask] #x co-ordiates upstream of grounding line
       glx2=wavi.gh.xx[2:end,:][glmask] #x co-ordinates immediately downstream

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using Test, TestSetExtensions, SafeTestsets, LinearAlgebra
 
         include("MISMIP_PLUS_test.jl")
         wavi=MISMIP_PLUS_test(20000)
-        glx=WAVI.get_GLx(wavi)
+        glx=WAVI.get_glx(wavi)
         glxtest=glx[[1,div(wavi.gh.ny,2),div(wavi.gh.ny,2)+1,wavi.gh.ny]]
         @test length(glxtest) == wavi.params.ny #check that the grounding line covers the whole domain in the y-direction
         @test (glxtest[4]-glxtest[1])/(glxtest[4]+glxtest[1]) < 1e-4


### PR DESCRIPTION
added a new method (taken straight from the tests section) to get the grounding line in the form x = x(y)