### PR TITLE
Added internal clock to the wavi structure

### DIFF
--- a/src/WAVI.jl
+++ b/src/WAVI.jl
@@ -230,9 +230,9 @@ end
 
 #Struct to hold information on wavelet-grid (v-component).
 @with_kw struct Clock{T <: Real}
-    start_time::T
-    time::Array{T,1}
-    dt::T
+start_time::T
+time::Array{T,1}
+dt::T #hello rob!
 end
 
 #Struct to hold model state comprised of all the above information.


### PR DESCRIPTION
Added structure to wavi structure containing clock info.  Internal clock necessary for controlling output without doing it manually (i.e. as in the current MISMIP_PLUS example on DevelopTests).