### PR TITLE
Dev #112: Add develop install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that WAVI requires Julia v1.5 or newer.
 Updating WAVI is also achieved using the package manager
 ```julia
 julia>using Pkg
-julia>Pkg.update("WAVI"))
+julia>Pkg.update("WAVI")
 ```
 Note that updating should be done with care as WAVI is still developing rapidly; while we aim to keep breaking changes to a minimum, this cannot be guaranteed at present.
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -38,6 +38,35 @@ If you'd like to contribute code to the project:
 6. Open a pull request against the `main` branch of the main repository.
 
 
+## Local development
+
+To set up WAVI for local development (e.g. to contribute or test changes), follow these steps:
+
+**Clone the repository and create branch as needed (above section)**:
+
+```bash
+git clone https://github.com/WAVI-ice-sheet-model/WAVI.jl.git
+cd WAVI.jl
+```
+
+Lets say this is cloned to: `/git/WAVI.jl`.
+
+### Editable install
+
+If you would like to use your local WAVI code in another project (i.e. outside of the WAVI repo), do the following from that project directory:
+
+```julia
+julia> ]
+
+(@v1.12) pkg>activate .
+
+(@v1.12) pkg>develop /git/WAVI.jl
+```
+
+This adds WAVI to your current project environment in editable mode, pointing to your local clone. Any changes you make to the code in `/git/WAVI.jl` will take effect immediately — just restart your Julia session or re-include the relevant files to see the updates.
+
+Make sure to update `/git/WAVI.jl` in the above example to match the actual location where you cloned the `WAVI.jl` repo.
+
 ## Pull Request Process
 
 Please ensure your pull request follows these guidelines:

--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -1,7 +1,8 @@
 # Installation instructions
 
-You can install the latest version of WAVI using the built-in package manager (accessed by pressing `]` in the
-Julia command prompt) to add the package and instantiate/build all dependencies
+## Overview
+
+You can install the latest version of WAVI using the built-in package manager to add the package and instantiate/build all dependencies:
 
 ```julia
 julia> using Pkg
@@ -10,6 +11,18 @@ julia> Pkg.add(url="https://github.com/WAVI-ice-sheet-model/WAVI.jl")
 
 julia> Pkg.instantiate()
 ```
+
+or, alternatively, you can use the shortcut `]` to trigger the Pkg REPL and run these simplified commands:
+
+```julia
+julia> ]
+
+(@v1.12) pkg>add https://github.com/WAVI-ice-sheet-model/WAVI.jl
+
+(@v1.12) pkg>instantiate
+```
+
+## Branch selection
 
 The above will install the WAVI code in the 'main' branch. To install code contained on a different branch, use the `rev` flag:
 
@@ -26,3 +39,4 @@ where `BranchName` should be replaced by the name of the branch containing the c
 Note that WAVI is only tested on Julia versions 1.5 and newer; stability cannot be guaranteed on newer versions!
 
 At this time, updating should be done with care, as WAVI is under rapid development. While we take care to avoid breaking changes, they may happen during this time. If anything does break, please open an issue and let us know!
+


### PR DESCRIPTION
- Added develop install section to Contributors Guide.
- Update main install instructions to show use of either `Pkg`, or the Pkg REPL to install.
- Remove extra closing bracket in README.

I omitted a direct `develop .` instead of activate and instantiate since wasn't sure if it was needed.

#112 