### PR TITLE
Update run_simulation.jl to use checkpoint path

### DIFF
--- a/src/Simulations/run_simulation.jl
+++ b/src/Simulations/run_simulation.jl
@@ -67,7 +67,7 @@ function run_simulation!(simulation)
         #check if we have hit a temporary checkpoint
         if mod(i,timestepping_params.n_iter_chkpt) == 0
             #output a temporary checkpoint
-            fname = string("Chkpt",chkpt_tag, ".jld2")
+            fname = string(timestepping_params.chkpt_path, "Chkpt",chkpt_tag, ".jld2")
             @save fname simulation
             chkpt_tag = (chkpt_tag == "A") ? "B" : "A"
             println("making temporary checkpoint at timestep number $(simulation.clock.n_iter)")
@@ -77,7 +77,7 @@ function run_simulation!(simulation)
         if mod(i,simulation.timestepping_params.n_iter_pchkpt) == 0
             #output a permanent checkpoint
             n_iter_string =  lpad(simulation.clock.n_iter, 10, "0"); #filename as a string with 10 digits
-            fname = string("PChkpt_",n_iter_string, ".jld2")
+            fname = string(timestepping_params.chkpt_path, "PChkpt_",n_iter_string, ".jld2")
             @save fname simulation
             println("making permanent checkpoint at timestep number $(simulation.clock.n_iter)")
         end


### PR DESCRIPTION
Update the `fname` instances to pick up the checkpoint path, ie `timestepping_params.chkpt_path`.

Bug found and solution proposed by @henryclara.

Closes #130.

