### PR TITLE
Add grids to the climate forcing functions

### DIFF
--- a/src/Simulations/run_simulation.jl
+++ b/src/Simulations/run_simulation.jl
@@ -122,11 +122,11 @@ end
 run_simulation!(s::Simulation) = run_simulation!(s.model, s.timestepping_params, s.output_params, s.clock)
 
 
-function update_climate_forcing!(model::AbstractModel)
-        @unpack surface_mass_balance, shelf_melt_rate, fracture = model
+function update_climate_forcing!(model::AbstractModel, clock)
+        @unpack surface_mass_balance, shelf_melt_rate, fracture, grid = model
 
-        update_climate_forcing!(surface_mass_balance, clock)
-        #update_climate_forcing!(shelf_melt_rate, clock)
+        update_climate_forcing!(surface_mass_balance, grid, clock)
+        update_climate_forcing!(shelf_melt_rate, grid, grid, clock)
         #update_climate_forcing!(fracture, clock)
 
     return nothing

--- a/src/SurfaceMassBalance/ISMIP7SMB.jl
+++ b/src/SurfaceMassBalance/ISMIP7SMB.jl
@@ -85,5 +85,6 @@ function update_climate_forcing!(surface_mass_balance::ISMIP7SMB, clock)
     vertical_smb_gradient_anomaly_ncfile = NCDataset(vertical_smb_gradient_anomaly_filename)
     vertical_smb_gradient .= replace(vertical_smb_gradient_anomaly_ncfile["dacabfdz"][:,:,:], missing => NaN)
     
+    return nothing
 
 end

--- a/src/SurfaceMassBalance/ISMIP7SMB.jl
+++ b/src/SurfaceMassBalance/ISMIP7SMB.jl
@@ -59,19 +59,13 @@ function update_accumulation_rate!(surface_mass_balance::ISMIP7SMB, model::Abstr
 end
 
 
-function update_climate_forcing!(surface_mass_balance::ISMIP7SMB, clock) 
+function update_climate_forcing!(surface_mass_balance::ISMIP7SMB, grid, clock) 
     @unpack smb_anomaly = surface_mass_balance
     @unpack vertical_smb_gradient = surface_mass_balance
 
     #get the year from clock for the forcing files
     current_time = clock.time + clock.ref_time
     current_time_string = string(Int(round(current_time)))
-
-    #read the grid resolution from the reference smb
-    (nx,ny) = size(surface_mass_balance.reference_smb)
-
-    #compute the grid size from the number of grid points
-    dx = 6088000.0 / nx 
 
     # load in the smb anomaly from ISMIP7
     resolution = join([string(Int(dx)), "m"])


### PR DESCRIPTION
Updating the climate forcing functions needs to know about the grid size, so we need to pass the grid through these functions. Have updated the corresponding function in the ISMIP7 SMB