### PR TITLE
Fix MPI halo blend bug, use rh and bh on the right and bottom edges

### DIFF
--- a/src/Specs/MPI/exchanges.jl
+++ b/src/Specs/MPI/exchanges.jl
@@ -79,8 +79,8 @@ function apply_halo_exchange_blends!(
                 (1.0 .- W_left) .* recv_left[:, j_mid] .+ W_left .* L0[1:lh, j_mid]
         end
     end
-    if right > -1 && lh > 0
-        ir = (nx - lh + 1):nx
+    if right > -1 && rh > 0
+        ir = (nx - rh + 1):nx
         if isempty(j_mid)
             local_field[ir, :] .= (1.0 .- W_right) .* recv_right .+ W_right .* L0[ir, :]
         else
@@ -96,8 +96,8 @@ function apply_halo_exchange_blends!(
                 (1.0 .- W_top) .* recv_top[i_mid, :] .+ W_top .* L0[i_mid, 1:th]
         end
     end
-    if bottom > -1 && th > 0
-        jb = (ny - th + 1):ny
+    if bottom > -1 && bh > 0
+        jb = (ny - bh + 1):ny
         if isempty(i_mid)
             local_field[:, jb] .= (1.0 .- W_bottom) .* recv_bottom .+ W_bottom .* L0[:, jb]
         else
@@ -113,26 +113,26 @@ function apply_halo_exchange_blends!(
             local_field[i, j] = (1 - wl) * (1 - wt) * RL + (1 - wl) * wt * RT + wl * L0[i, j]
         end
     end
-    if right > -1 && top > -1 && lh > 0 && th > 0
-        for j in 1:th, i_loc in 1:lh
-            i = nx - lh + i_loc
+    if right > -1 && top > -1 && rh > 0 && th > 0
+        for j in 1:th, i_loc in 1:rh
+            i = nx - rh + i_loc
             wr, wt = W_right[i_loc], W_top[1, j]
             RR, RT = recv_right[i_loc, j], recv_top[i, j]
             local_field[i, j] = (1 - wr) * (1 - wt) * RR + (1 - wr) * wt * RT + wr * L0[i, j]
         end
     end
-    if left > -1 && bottom > -1 && lh > 0 && th > 0
-        for j_loc in 1:th, i in 1:lh
-            j = ny - th + j_loc
+    if left > -1 && bottom > -1 && lh > 0 && bh > 0
+        for j_loc in 1:bh, i in 1:lh
+            j = ny - bh + j_loc
             wl, wb = W_left[i], W_bottom[1, j_loc]
             RL, RB = recv_left[i, j], recv_bottom[i, j_loc]
             local_field[i, j] = (1 - wl) * (1 - wb) * RL + (1 - wl) * wb * RB + wl * L0[i, j]
         end
     end
-    if right > -1 && bottom > -1 && lh > 0 && th > 0
-        for j_loc in 1:th, i_loc in 1:lh
-            i = nx - lh + i_loc
-            j = ny - th + j_loc
+    if right > -1 && bottom > -1 && rh > 0 && bh > 0
+        for j_loc in 1:bh, i_loc in 1:rh
+            i = nx - rh + i_loc
+            j = ny - bh + j_loc
             wr, wb = W_right[i_loc], W_bottom[1, j_loc]
             RR, RB = recv_right[i_loc, j], recv_bottom[i, j_loc]
             local_field[i, j] = (1 - wr) * (1 - wb) * RR + (1 - wr) * wb * RB + wr * L0[i, j]

--- a/test/mpi_tests/test_mpispec_halo_collect.jl
+++ b/test/mpi_tests/test_mpispec_halo_collect.jl
@@ -32,6 +32,35 @@ using WAVI
         return model
     end
 
+    # Direct apply: left/right and top/bottom halo widths can differ (lh=0, rh=2, th=1, bh=2).
+    @testset "apply_halo_exchange_blends! uses rh and bh" begin
+        nx, ny = 8, 7
+        lh, rh, th, bh = 0, 2, 1, 2
+        local_field = fill(0.0, nx, ny)
+        L0 = fill(-1.0, nx, ny)
+        recv_right = fill(10.0, rh, ny)
+        recv_top = fill(30.0, nx, th)
+        recv_bottom = fill(20.0, nx, bh)
+        W_right = zeros(rh)
+        W_top = zeros(1, th)
+        W_bottom = zeros(1, bh)
+        WAVI.Specs.apply_halo_exchange_blends!(
+            local_field, L0,
+            nothing, recv_right, recv_top, recv_bottom,
+            zeros(0), W_right, W_top, W_bottom,
+            lh, rh, th, bh, nx, ny,
+            -1, 1, 1, 1,
+        )
+        j_mid = (th + 1):(ny - bh)
+        i_mid = (lh + 1):(nx - rh)
+        @test all(local_field[(nx - rh + 1):nx, j_mid] .== 10.0)
+        @test all(local_field[i_mid, (ny - bh + 1):ny] .== 20.0)
+        @test all(local_field[i_mid, 1:th] .== 30.0)
+        # Zero weights: right-bottom corner uses recv_right (see apply_halo_exchange_blends!).
+        @test all(local_field[(nx - rh + 1):nx, (ny - bh + 1):ny] .== 10.0)
+        @test all(local_field[i_mid, j_mid] .== 0.0)
+    end
+
     # After exchange, the left halo should hold the left neighbour's core thickness (rank 1 on a 2×1 split).
     @testset "halo_exchange! updates rank-neighbour h halos" begin
         model = build_model(halo = 1, pou = false)
@@ -44,6 +73,9 @@ using WAVI
 
         if model.spec.left > -1 && lh > 0
             @test all(h[1:lh, :] .== (model.spec.left + 1.0))
+        end
+        if model.spec.right > -1 && rh > 0
+            @test all(h[(end - rh + 1):end, :] .== (model.spec.right + 1.0))
         end
     end
 


### PR DESCRIPTION
Fixes: #163

## Description
- MPI halo blending was checking the wrong side widths: the right edge used the left width, and the bottom edge used the top width.
- On ranks with a neighbour on only one side (for example the left column of a multi-column split), the neighbour data was received and then ignored, so those halos stayed stale.
- This patch uses `rh` and `bh` for the right and bottom edges and corners, and adds tests that catch the skipped-blend case.
